### PR TITLE
Add PERVANE_HOME configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ pip install --upgrade pervane
 
 ## Options
 
-* `--dir`: Note root directory. File tree will be generated from this.
+* `--dir`: Note root directory. File tree will be generated from this. If PERVANE_HOME environment variable is set and --dir is not provided, PERVANE_HOME is used.
 * `--host`: defaults to 0.0.0.0. Hostname to be binded.
 * `--port`: defaults to 5000. Port number to be binded.
 * `--username`: DEPRECATED. Authentication is now based on cookie based login. defaults to 'hakuna'. Username for basic http auth.

--- a/pervane/serve.py
+++ b/pervane/serve.py
@@ -72,8 +72,9 @@ parser.add_argument('--host', dest='host', default='0.0.0.0',
                     help='hostname to be binded')
 parser.add_argument('--port', dest='port', default='5000',
                     help='port to be binded')
-parser.add_argument('--dir', dest='root_dir', default='./',
-                    help='Working folder to show the tree.')
+parser.add_argument('--dir', dest='root_dir', default=os.environ.get("PERVANE_HOME", "./"),
+                    help='Working folder to show the tree. If PERVANE_HOME environment variable is '
+                    'set and --dir is not provided, PERVANE_HOME is used.')
 parser.add_argument('--username', dest='username', default=None,
                     help='This is deprecated, please use cookie based login.')
 parser.add_argument('--password', dest='password', default=None,

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="pervane",
-    version="0.0.47",
+    version="0.0.48",
     author="hakanu",
     author_email="hi@hakanu.net",
     description="Plain text backed web based markdown note taking and knowledge base building app",


### PR DESCRIPTION
If PERVANE_HOME is set and --dir is not provided, PERVANE_HOME is used
as the root directory. Pervane version is also incremented for the new
release.