### PR TITLE
AES encrypted ZIP files and Tombo CHI encryption file support

### DIFF
--- a/pervane/serve.py
+++ b/pervane/serve.py
@@ -686,7 +686,7 @@ def api_get_content_handler():
         'mod_time': mod_time
     })
   except Exception as e:
-    logging.error('There is an error while reading: %s. Error: %s', path, str(e))
+    logging.error('There is an error while writing: %s.', path, exc_info=True)
     # Don't leak the absolute path.
     # NOTE this error is not propagated to the client :-( https://github.com/hakanu/pervane/issues/152
     return _failure_json(('Reading %s failed' % requested_path))

--- a/pervane/serve.py
+++ b/pervane/serve.py
@@ -667,7 +667,6 @@ def api_update_handler():
 
 
   try:
-    # TODO implement encrypted write/update
     with AtomicFile(path, file_mode) as f:
       if handler_class:
           crypto_password = debug_get_password()

--- a/pervane/serve.py
+++ b/pervane/serve.py
@@ -579,6 +579,12 @@ class TomboBlowfish:
 file_type_handlers = {
     '.chi': TomboBlowfish,  # created by http://tombo.osdn.jp/En/
 }
+def filename2handler(filename):
+    _dummy, file_extn = os.path.splitext(filename.lower())
+    handler_class = file_type_handlers.get(file_extn)
+    logging.error('clach04 DEBUG file_extn: %r', file_extn)
+    logging.error('clach04 DEBUG handler_class: %r', handler_class)
+    return handler_class
 
 @app.route('/api/get_content')
 @login_required
@@ -596,10 +602,7 @@ def api_get_content_handler():
   try:
     mod_time = _get_file_mod_time(path)
 
-    _dummy, file_extn = os.path.splitext(path.lower())
-    handler_class = file_type_handlers.get(file_extn)
-    logging.error('clach04 DEBUG file_extn: %r', file_extn)
-    logging.error('clach04 DEBUG handler_class: %r', handler_class)
+    handler_class = filename2handler(path)
     if handler_class:
         crypto_key = os.getenv('DEBUG_CRYPTO_KEY', 'test password')
         crypto_key = os.getenv('DEBUG_CRYPTO_KEY', 'test')
@@ -643,10 +646,7 @@ def api_update_handler():
   if err:
     return _failure_json(err)
 
-  _dummy, file_extn = os.path.splitext(path.lower())
-  handler_class = file_type_handlers.get(file_extn)
-  logging.error('clach04 DEBUG file_extn: %r', file_extn)
-  logging.error('clach04 DEBUG handler_class: %r', handler_class)
+  handler_class = filename2handler(path)
   if handler_class:
       file_mode = 'wb'
   else:

--- a/pervane/serve.py
+++ b/pervane/serve.py
@@ -585,6 +585,12 @@ def filename2handler(filename):
     logging.error('clach04 DEBUG file_extn: %r', file_extn)
     logging.error('clach04 DEBUG handler_class: %r', handler_class)
     return handler_class
+#def debug_get_password():
+def debug_get_key():
+    # DEBUG this should be a callback mechanism
+    crypto_key = os.getenv('DEBUG_CRYPTO_KEY', 'test')  # dumb default password, should raise exception on missing password
+    logging.error('clach04 DEBUG key: %r', crypto_key)
+    return crypto_key
 
 @app.route('/api/get_content')
 @login_required
@@ -604,9 +610,7 @@ def api_get_content_handler():
 
     handler_class = filename2handler(path)
     if handler_class:
-        crypto_key = os.getenv('DEBUG_CRYPTO_KEY', 'test password')
-        crypto_key = os.getenv('DEBUG_CRYPTO_KEY', 'test')
-        logging.error('clach04 DEBUG key: %r', crypto_key)
+        crypto_key = debug_get_key()
         # TODO string key to bytes
         crypto_key = crypto_key.encode('utf8')
         handler = handler_class(crypto_key)
@@ -657,9 +661,7 @@ def api_update_handler():
     # TODO implement encrypted write/update
     with AtomicFile(path, file_mode) as f:
       if handler_class:
-          crypto_key = os.getenv('DEBUG_CRYPTO_KEY', 'test password')
-          crypto_key = os.getenv('DEBUG_CRYPTO_KEY', 'test')
-          logging.error('clach04 DEBUG key: %r', crypto_key)
+          crypto_key = debug_get_key()
           # TODO string key to bytes
           crypto_key = crypto_key.encode('utf8')
           handler = handler_class(crypto_key)

--- a/pervane/serve.py
+++ b/pervane/serve.py
@@ -720,7 +720,7 @@ def api_get_content_handler():
         'mod_time': mod_time
     })
   except Exception as e:
-    logging.error('There is an error while writing: %s.', path, exc_info=True)
+    logging.error('There is an error while reading: %s.', path, exc_info=True)
     # Don't leak the absolute path.
     # NOTE this error is not propagated to the client :-( https://github.com/hakanu/pervane/issues/152
     return _failure_json(('Reading %s failed' % requested_path))

--- a/pervane/serve.py
+++ b/pervane/serve.py
@@ -763,7 +763,7 @@ def api_update_handler():
     logging.error('There is an error while writing: %s. Error: %r', path, e)
     logging.error('There is an error while writing: %s.', path, exc_info=True)
     # Don't leak the absolute path.
-    # TODO errors not materelized to frontend, no idea failure occured :-(
+    # TODO error do not materialize to frontend, user has no idea failure occurred :-(
     return _failure_json(('Writing %s failed' % requested_path))
 
 

--- a/pervane/serve.py
+++ b/pervane/serve.py
@@ -598,6 +598,15 @@ class EncryptedFile:
 
 
 class TomboBlowfish(EncryptedFile):
+    """Read/write Tombo (modified) Blowfish encrypted files
+    Compatible with files in:
+
+      * Tombo - http://tombo.osdn.jp/En/
+      * Kumagusu - https://osdn.net/projects/kumagusu/ and https://play.google.com/store/apps/details?id=jp.gr.java_conf.kumagusu
+      * miniNoteViewer - http://hatapy.web.fc2.com/mininoteviewer.html and https://play.google.com/store/apps/details?id=jp.gr.java_conf.hatalab.mnv&hl=en_US&gl=US
+
+    """
+
     def read_from(self, full_pathname):
         return chi_io.read_encrypted_file(full_pathname, self.key)
 
@@ -606,7 +615,17 @@ class TomboBlowfish(EncryptedFile):
 
 
 class ZipAES(EncryptedFile):
+    """Read/write ZIP AES(256) encrypted files (not old ZipCrypto)
+    Compatible with files in WinZIP and 7z.
+
+    Example 7z demo (Windows or Linux, assuming 7z is in the path):
+
+        echo encrypted > encrypted.md
+        7z a -ptest test_file.aes.zip encrypted.md
+    """
+
     _filename = 'encrypted.md'
+
     def read_from(self, full_pathname):
         with pyzipper.AESZipFile(full_pathname) as zf:
             zf.setpassword(self.key)


### PR DESCRIPTION
Implements a proof of concept to allow reading and writing of encrypted files (#99).

  * Supports ZIP AES256 (should read AES128) compatible with WinZIP and 7z so the encrypted files are not tied to Pervane
  * Supports Tombo encrypted files 

Missing is a way to set (and unset) password, this demo picks up the password from the operating system environment variable `DEBUG_CRYPTO_KEY`(and if missing defaults to "test").

Also there is no error reporting to the client on bad passwords, there is currently no reporting to the client for any error (see https://github.com/hakanu/pervane/issues/152)

The change also includes workarounds (or solutions) for:

  * AtomicFile limitations/unmaintained - https://github.com/hakanu/pervane/issues/155
  * Server errors lost - https://github.com/hakanu/pervane/issues/154

I have no idea how to tackle:

  * notify user of errors - https://github.com/hakanu/pervane/issues/152 - this seems critical
  * prompting web browser user for password
  * Windows support - https://github.com/hakanu/pervane/issues/153 - probably low priority (but would be nice to have)
